### PR TITLE
Flink 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM gradle:8.6.0-jdk11 as builder
 COPY . .
 RUN gradle shadowJar
 
-FROM flink:1.18.1-java11
-RUN echo "metrics.reporters: prom" >> "$FLINK_HOME/conf/flink-conf.yaml"; \
-    echo "metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory" >> "$FLINK_HOME/conf/flink-conf.yaml"
+FROM flink:1.19.0-java11
+RUN echo "metrics.reporters: prom" >> "$FLINK_HOME/conf/config.yaml"; \
+    echo "metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory" >> "$FLINK_HOME/conf/config.yaml"
 COPY --from=builder /home/gradle/build/libs/*.jar $FLINK_HOME/usrlib/
 RUN mkdir /state && chown flink:flink /state  # workaround for https://github.com/docker/compose/issues/3270

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Actions Status](https://github.com/mbode/flink-prometheus-example/workflows/Gradle/badge.svg)](https://github.com/mbode/flink-prometheus-example/actions)
 [![codecov](https://codecov.io/gh/mbode/flink-prometheus-example/branch/master/graph/badge.svg)](https://codecov.io/gh/mbode/flink-prometheus-example)
-[![Flink v1.18.1](https://img.shields.io/badge/flink-v1.18.1-blue.svg)](https://github.com/apache/flink/releases/tag/release-1.18.1)
+[![Flink v1.19.0](https://img.shields.io/badge/flink-v1.19.0-blue.svg)](https://github.com/apache/flink/releases/tag/release-1.19.0)
 [![Prometheus v2.37.1](https://img.shields.io/badge/prometheus-v2.37.1-blue.svg)](https://github.com/prometheus/prometheus/releases/tag/v2.37.1)
 
 This repository contains the live demo to my talk _Monitoring Flink with Prometheus_, which I have given at:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ java {
 
 repositories { mavenCentral() }
 
-val flinkVersion = "1.18.1"
+val flinkVersion = "1.19.0"
 
 dependencies {
     compileOnly("org.apache.flink:flink-java:$flinkVersion")


### PR DESCRIPTION
Bumps `flinkVersion` from 1.18.1 to 1.19.0.

Updates `org.apache.flink:flink-java` from 1.18.1 to 1.19.0
- [Commits](https://github.com/apache/flink/compare/release-1.18.1...release-1.19.0)

Updates `org.apache.flink:flink-streaming-java` from 1.18.1 to 1.19.0
- [Commits](https://github.com/apache/flink/compare/release-1.18.1...release-1.19.0)

Updates `org.apache.flink:flink-test-utils` from 1.18.1 to 1.19.0

---
updated-dependencies:
- dependency-name: org.apache.flink:flink-java dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.flink:flink-streaming-java dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.flink:flink-test-utils dependency-type: direct:production update-type: version-update:semver-minor ...