### PR TITLE
Rework gradle-related GitHub actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,8 +14,8 @@ jobs:
         with:
           distribution: zulu
           java-version: 11
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3.5.0
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Check with Gradle
         run: ./gradlew check
       - name: Integration Test with Gradle


### PR DESCRIPTION
https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation