### PR TITLE
Bump Gradle from 9.3.1 to 9.6.1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6.3.0
       - name: Check with Gradle
         run: ./gradlew check
       - name: Integration Test with Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:9.3.1-jdk21 as builder
+FROM gradle:9.6.1-jdk21 as builder
 COPY . .
 RUN gradle shadowJar
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Upgrades Gradle to the latest release (9.6.1):

- `gradle-wrapper.properties`: 9.3.1 → 9.6.1
- `Dockerfile`: `gradle:9.3.1-jdk21` → `gradle:9.6.1-jdk21`
- `.github/workflows/gradle.yml`: `setup-gradle@v5` → `setup-gradle@v6.3.0` (latest)

Release notes: https://docs.gradle.org/9.6.1/release-notes.html