### PR TITLE
Bump Flink from 2.1.1 to 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM gradle:9.6.1-jdk21 as builder
 COPY . .
 RUN gradle shadowJar
 
-FROM flink:2.1.1-java21
+FROM flink:2.3.0-java21
 RUN echo "metrics.reporters: prom" >> "$FLINK_HOME/conf/config.yaml"; \
     echo "metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory" >> "$FLINK_HOME/conf/config.yaml"
 COPY --from=builder /home/gradle/build/libs/*.jar $FLINK_HOME/usrlib/
-RUN mkdir /state && chown flink:flink /state  # workaround for https://github.com/docker/compose/issues/3270

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ java {
 
 repositories { mavenCentral() }
 
-val flinkVersion = "2.1.1"
+val flinkVersion = "2.3.0"
 
 dependencies {
     compileOnly("org.apache.flink:flink-streaming-java:$flinkVersion")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,42 +6,36 @@ services:
     ports:
     - "8081:8081"
     - "9249:9249"
-    volumes:
-    - state:/state
     command: standalone-job --job-classname com.github.mbode.flink_prometheus_example.PrometheusExampleJob --job-id 00000000000000000000000000000000
     environment:
     - |
       FLINK_PROPERTIES=
       jobmanager.rpc.address: job-cluster
-      state.checkpoints.dir: file:///state
+      state.checkpoints.dir: file:///tmp/flink-state
 
   taskmanager1:
     build: .
     container_name: taskmanager1
     ports:
     - "9250:9249"
-    volumes:
-    - state:/state
     command: taskmanager
     environment:
     - |
       FLINK_PROPERTIES=
       jobmanager.rpc.address: job-cluster
-      state.checkpoints.dir: file:///state
+      state.checkpoints.dir: file:///tmp/flink-state
 
   taskmanager2:
     build: .
     container_name: taskmanager2
     ports:
     - "9251:9249"
-    volumes:
-    - state:/state
     command: taskmanager
     environment:
     - |
       FLINK_PROPERTIES=
       jobmanager.rpc.address: job-cluster
-      state.checkpoints.dir: file:///state
+      state.checkpoints.dir: file:///tmp/flink-state
 
   prometheus:
     image: prom/prometheus:v3.6.0
@@ -61,6 +55,3 @@ services:
     - GF_SECURITY_ADMIN_PASSWORD=flink
     volumes:
     - ./grafana/provisioning/:/etc/grafana/provisioning/
-
-volumes:
-  state:


### PR DESCRIPTION
Combines dependabot PRs #570 (Maven `flinkVersion`) and #575 (Docker base image).

The `flink:2.3.0-java21` image runs as the non-root `flink` user by default, so the previous `mkdir /state && chown` workaround fails. Switch the checkpoint directory to `/tmp/flink-state` (writable by any user) and drop the now-unnecessary named volume.

Closes #570, closes #575.